### PR TITLE
Update README.md with IMX678 performances

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ See the documentation for more details about each interface.
 
 **Suggested resolutions**
 
-The performances reported in the table below are referred to the FRAMOS-IMX415 cameras.
+The performances reported in the table below are referred to the FRAMOS-IMX678 cameras.
 
 |resolution|carrier|fps w/ CUDA|fps w/o CUDA|
 |:-:|:-:|:-:|:-:|
-|640x480|mjpeg|75|90|
-|1920x1080|mjpeg|40|50|
-|3840x2160|mjpeg|9|12|
+|1920x1080|mjpeg|40|33|
+|2560x1440|mjpeg|20|20|
+|3840x2160|mjpeg|10|10|
 
 # 4. Information for developers
 

--- a/src/devices/argusCamera/argusCameraDriver.cpp
+++ b/src/devices/argusCamera/argusCameraDriver.cpp
@@ -49,7 +49,7 @@ static const std::map<double, double> rotationToCVRot{{0.0, 0.0}, {90.0, cv::ROT
 
 static const std::map<std::string, std::vector<Argus::Size2D<uint32_t>>> cameraResolutions{
     {"imx415", {Size2D<uint32_t>(1280, 720), Size2D<uint32_t>(1920, 1080), Size2D<uint32_t>(3840, 2160)}},
-    {"imx678", {Size2D<uint32_t>(3856, 2180), Size2D<uint32_t>(2608, 1964), Size2D<uint32_t>(1920, 1080)}}
+    {"imx678", {Size2D<uint32_t>(3840, 2160), Size2D<uint32_t>(2560, 1440), Size2D<uint32_t>(1920, 1080)}}
 };
 
 // We usually set the features through a range between 0 an 1, we have to translate it in meaninful value for the camera


### PR DESCRIPTION
This PR addresses:

- the update of the documentation related to the performance of the FRAMOS-IMX678 cameras with and without CUDA
- define as the available resolutions the standards (FHD, 2K, 4K) and not the provided ones since they produce broke images as output (we have already faced this problem with the IMX415, see https://github.com/icub-tech-iit/study-icub-headedge/issues/94)

The performances reported in the table were obtained by launching the `yarp-device-argus` device (via yarprobotinterface) and the `yarpview` both from the Orin NX board. 

Here the `jtop` output in the two cases:

### with CUDA

![withcuda](https://github.com/user-attachments/assets/5800aa73-132c-4b44-aef0-b8f9f4c9fffb)

### without CUDA

![withoutcuda](https://github.com/user-attachments/assets/7d11890b-e84a-4b3e-ae7c-5e9e392f0c39)

As you can see, the CPU% is considerably reduced when the image processing is moved on the GPU